### PR TITLE
Support for all flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 0.3.0
+
+* Adding all flags support.
+
 ## 0.2.0
 
-* Adding real-time updates support.
+* Adding real-time updates support for feature flags.
 
 ## 0.1.7
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.oakam.launchdarkly_flutter'
-version '0.2.0'
+version '0.3.0'
 
 buildscript {
     repositories {

--- a/android/src/main/java/com/oakam/launchdarkly_flutter/LaunchdarklyFlutterPlugin.java
+++ b/android/src/main/java/com/oakam/launchdarkly_flutter/LaunchdarklyFlutterPlugin.java
@@ -125,7 +125,9 @@ public class LaunchdarklyFlutterPlugin implements FlutterPlugin, ActivityAware, 
       String flagKey = call.argument("flagKey");
       String fallback = call.argument("fallback");
       result.success(ldClient.stringVariation(flagKey,fallback));
-    } else if (call.method.equals("registerFeatureFlagListener")) {
+    } else if (call.method.equals("allFlags")) {
+      result.success(ldClient.allFlags());
+    }else if (call.method.equals("registerFeatureFlagListener")) {
 
       String flagKey = call.argument("flagKey");
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -13,6 +13,7 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   bool _shouldShow = false;
   bool _listenerRegistered = false;
+  Map<String, dynamic> _allFlags = {};
   LaunchdarklyFlutter launchdarklyFlutter;
 
   String mobileKey = 'YOUR_MOBILE_KEY';
@@ -86,6 +87,14 @@ class _MyAppState extends State<MyApp> {
                     ? 'Unregister listener'
                     : 'Register listener'),
               ),
+              SizedBox(height: 30.0,),
+              RaisedButton(
+                onPressed: () async {
+                  _verifyAllFlags();
+                },
+                child: Text('Verify all flags'),
+              ),
+              Text('All flags: $_allFlags\n'),
             ],
           ),
         ),
@@ -109,6 +118,25 @@ class _MyAppState extends State<MyApp> {
 
     setState(() {
       _shouldShow = shouldShow;
+    });
+  }
+
+  void _verifyAllFlags() async {
+    Map<String, dynamic> allFlags;
+    // Platform messages may fail, so we use a try/catch PlatformException.
+    try {
+      allFlags = await launchdarklyFlutter.allFlags();
+    } on PlatformException {
+      allFlags = {};
+    }
+
+    // If the widget was removed from the tree while the asynchronous platform
+    // message was in flight, we want to discard the reply rather than calling
+    // setState to update our non-existent appearance.
+    if (!mounted) return;
+
+    setState(() {
+      _allFlags = allFlags;
     });
   }
 }

--- a/ios/Classes/SwiftLaunchdarklyFlutterPlugin.swift
+++ b/ios/Classes/SwiftLaunchdarklyFlutterPlugin.swift
@@ -22,7 +22,7 @@ import LaunchDarkly
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult)  {
-    let arguments = call.arguments as! [String:Any]
+    let arguments = call.arguments as? [String:Any] ?? [:]
     
     if (call.method == "init") {
         
@@ -76,7 +76,13 @@ import LaunchDarkly
                
         result(LDClient.shared.variation(forKey: flagKey, fallback: fallback) as String)
         
-    } else if(call.method == "registerFeatureFlagListener") {
+    } else if(call.method == "allFlags") {
+        
+        let allFlags = LDClient.shared.allFlagValues ?? [:]
+               
+        result(allFlags)
+        
+    }else if(call.method == "registerFeatureFlagListener") {
         
         let flagKey = arguments["flagKey"] as? String ?? ""
         

--- a/ios/launchdarkly_flutter.podspec
+++ b/ios/launchdarkly_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'launchdarkly_flutter'
-  s.version          = '0.2.0'
+  s.version          = '0.3.0'
   s.summary          = 'A Flutter LaunchDarkly SDK.'
   s.description      = <<-DESC
 This is an unofficial LaunchDarkly SDK for Flutter, for anyone willing to use LaunchDarkly in a Flutter app.

--- a/lib/launchdarkly_flutter.dart
+++ b/lib/launchdarkly_flutter.dart
@@ -122,4 +122,11 @@ class LaunchdarklyFlutter {
     return await _channel.invokeMethod(
         'unregisterFeatureFlagListener', <String, dynamic>{'flagKey': flagKey});
   }
+
+  /// Returns a map of all feature flags for the current user. No events are sent to LaunchDarkly.
+  Future<Map<String, dynamic>> allFlags() async {
+    Map<String, dynamic> allFlags =
+        Map<String, dynamic>.from(await _channel.invokeMethod('allFlags'));
+    return allFlags;
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: launchdarkly_flutter
 description: This is an unofficial LaunchDarkly SDK for Flutter, for anyone willing to use LaunchDarkly in a Flutter app.
-version: 0.2.0
+version: 0.3.0
 homepage: https://github.com/andre-paraense/launchdarkly_flutter
 issue_tracker: https://github.com/andre-paraense/launchdarkly_flutter/issues
 

--- a/test/launchdarkly_flutter_test.dart
+++ b/test/launchdarkly_flutter_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:launchdarkly_flutter/launchdarkly_flutter.dart';
@@ -45,6 +47,11 @@ void main() {
 
       if (methodCall.method == 'unregisterFeatureFlagListener') {
         return true;
+      }
+
+      if (methodCall.method == 'allFlags') {
+        Map<String, dynamic> response = jsonDecode('{"flagKey":true}');
+        return response;
       }
 
       return launchdarklyFlutter.handlerMethodCalls(methodCall);
@@ -196,5 +203,11 @@ void main() {
         await channel.invokeMethod(
             'callbackRegisterFeatureFlagListener', arguments),
         true);
+  });
+
+  test('allFlags', () async {
+    Map<String, dynamic> response = await launchdarklyFlutter.allFlags();
+
+    expect(response['flagKey'], true);
   });
 }


### PR DESCRIPTION
### Requirements

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

### Related issues

Issue #13 

### Describe the solution you've provided

I have provided access to the Android `allFlags()` and the iOS `allFlagsvalues` methods in each LaunchDarkly SDKs over platform channels.

### Describe alternatives you've considered

An alternative would have been the use of REST API calls. Not the direction being taken in this plugin, though.

### Additional context

N/A

### How to test?

Run the example app with your keys and give it a try! ;)

### Future works

Provide support for the all flags listener.
