### PR TITLE
All flags listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0
+
+* Adding all flags listener support.
+
 ## 0.3.0
 
 * Adding all flags support.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.oakam.launchdarkly_flutter'
-version '0.3.0'
+version '0.4.0'
 
 buildscript {
     repositories {

--- a/android/src/main/java/com/oakam/launchdarkly_flutter/LaunchdarklyFlutterPlugin.java
+++ b/android/src/main/java/com/oakam/launchdarkly_flutter/LaunchdarklyFlutterPlugin.java
@@ -1,6 +1,9 @@
 package com.oakam.launchdarkly_flutter;
 
 import android.app.Activity;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 
@@ -136,11 +139,19 @@ public class LaunchdarklyFlutterPlugin implements FlutterPlugin, ActivityAware, 
 
       FeatureFlagChangeListener listener = new FeatureFlagChangeListener() {
         @Override
-        public void onFeatureFlagChange(String flagKey) {
-          Map<String, String> arguments = new HashMap<>();
-          arguments.put("flagKey",flagKey);
-
-          channel.invokeMethod("callbackRegisterFeatureFlagListener",arguments);
+        public void onFeatureFlagChange(final String flagKey) {
+          new Handler(Looper.getMainLooper()).post(new Runnable() {
+            @Override
+            public void run() {
+              Map<String, String> arguments = new HashMap<>();
+              arguments.put("flagKey",flagKey);
+              try{
+                channel.invokeMethod("callbackRegisterFeatureFlagListener",arguments);
+              }catch (Exception e){
+                Log.e("FeatureFlagsListener", e.getMessage());
+              }
+            }
+          });
         }
       };
 
@@ -162,11 +173,20 @@ public class LaunchdarklyFlutterPlugin implements FlutterPlugin, ActivityAware, 
 
       LDAllFlagsListener listener = new LDAllFlagsListener() {
         @Override
-        public void onChange(List<String> flagKeys) {
-          Map<String, List<String>> arguments = new HashMap<>();
-          arguments.put("flagKeys",flagKeys);
+        public void onChange(final List<String> flagKeys) {
+          new Handler(Looper.getMainLooper()).post(new Runnable() {
+            @Override
+            public void run() {
+              Map<String, List<String>> arguments = new HashMap<>();
+              arguments.put("flagKeys",flagKeys);
 
-          channel.invokeMethod("callbackAllFlagsListener",arguments);
+              try{
+                channel.invokeMethod("callbackAllFlagsListener",arguments);
+              }catch (Exception e){
+                Log.e("callAllFlagsListener", e.getMessage());
+              }
+            }
+          });
         }
       };
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -17,9 +17,9 @@ class _MyAppState extends State<MyApp> {
   bool _listenerAllFlagsRegistered = false;
   LaunchdarklyFlutter launchdarklyFlutter;
 
-  String mobileKey = 'mob-6924202b-5eb3-4eb7-b665-0b74c7720960';
-  String userId = '1';
-  String flagKey = 'w-0-on-the-app';
+  String mobileKey = 'YOUR_MOBILE_KEY';
+  String userId = 'USER_ID';
+  String flagKey = 'FLAG_KEY';
 
   @override
   void initState() {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -14,11 +14,12 @@ class _MyAppState extends State<MyApp> {
   bool _shouldShow = false;
   bool _listenerRegistered = false;
   Map<String, dynamic> _allFlags = {};
+  bool _listenerAllFlagsRegistered = false;
   LaunchdarklyFlutter launchdarklyFlutter;
 
-  String mobileKey = 'YOUR_MOBILE_KEY';
-  String userId = 'USER_ID';
-  String flagKey = 'FLAG_KEY';
+  String mobileKey = 'mob-6924202b-5eb3-4eb7-b665-0b74c7720960';
+  String userId = '1';
+  String flagKey = 'w-0-on-the-app';
 
   @override
   void initState() {
@@ -90,9 +91,40 @@ class _MyAppState extends State<MyApp> {
               SizedBox(height: 30.0,),
               RaisedButton(
                 onPressed: () async {
-                  _verifyAllFlags();
+                  _verifyAllFlags([]);
                 },
                 child: Text('Verify all flags'),
+              ),
+              RaisedButton(
+                onPressed: () async {
+                  if (_listenerAllFlagsRegistered) {
+                    try {
+                      setState(() {
+                        _listenerAllFlagsRegistered = false;
+                      });
+                      await launchdarklyFlutter
+                          .unregisterAllFlagsListener('allFlags');
+                    } on PlatformException {
+                      setState(() {
+                        _listenerAllFlagsRegistered = true;
+                      });
+                    }
+                  } else {
+                    try {
+                      setState(() {
+                        _listenerAllFlagsRegistered = true;
+                      });
+                      await launchdarklyFlutter.registerAllFlagsListener('allFlags', _verifyAllFlags);
+                    } on PlatformException {
+                      setState(() {
+                        _listenerAllFlagsRegistered = false;
+                      });
+                    }
+                  }
+                },
+                child: Text(_listenerAllFlagsRegistered
+                    ? 'Unregister All Flags listener'
+                    : 'Register All Flags listener'),
               ),
               Text('All flags: $_allFlags\n'),
             ],
@@ -121,7 +153,7 @@ class _MyAppState extends State<MyApp> {
     });
   }
 
-  void _verifyAllFlags() async {
+  void _verifyAllFlags(List<String> flagKeys) async {
     Map<String, dynamic> allFlags;
     // Platform messages may fail, so we use a try/catch PlatformException.
     try {

--- a/ios/Classes/SwiftLaunchdarklyFlutterPlugin.swift
+++ b/ios/Classes/SwiftLaunchdarklyFlutterPlugin.swift
@@ -91,7 +91,9 @@ import LaunchDarkly
         LDClient.shared.observe(keys: [flagKey], owner: flagObserverOwner, handler: { (changedFlags) in
             if changedFlags[flagKey] != nil {
                 let flagKeyMap = ["flagKey": flagKey]
-                FlutterChannel.shared.channel?.invokeMethod("callbackRegisterFeatureFlagListener", arguments: flagKeyMap)
+                DispatchQueue.main.async {
+                  FlutterChannel.shared.channel?.invokeMethod("callbackRegisterFeatureFlagListener", arguments: flagKeyMap)
+                }
             }
         })
         
@@ -123,7 +125,9 @@ import LaunchDarkly
                 allFlagsChanged.append(key)
             }
             let flagKeyMap = ["flagKeys": allFlagsChanged]
-            FlutterChannel.shared.channel?.invokeMethod("callbackAllFlagsListener", arguments: flagKeyMap)
+            DispatchQueue.main.async {
+              FlutterChannel.shared.channel?.invokeMethod("callbackAllFlagsListener", arguments: flagKeyMap)
+            }
         }
         
         FlutterChannel.shared.listeners[listenerId] = allFlagsObserverOwner;

--- a/ios/launchdarkly_flutter.podspec
+++ b/ios/launchdarkly_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'launchdarkly_flutter'
-  s.version          = '0.3.0'
+  s.version          = '0.4.0'
   s.summary          = 'A Flutter LaunchDarkly SDK.'
   s.description      = <<-DESC
 This is an unofficial LaunchDarkly SDK for Flutter, for anyone willing to use LaunchDarkly in a Flutter app.

--- a/lib/launchdarkly_flutter.dart
+++ b/lib/launchdarkly_flutter.dart
@@ -23,6 +23,10 @@ class LaunchdarklyFlutter {
   Future<dynamic> handlerMethodCalls(MethodCall call) async {
     switch (call.method) {
       case 'callbackRegisterFeatureFlagListener':
+        if (call.arguments == null) {
+          return false;
+        }
+
         if (!call.arguments.containsKey('flagKey')) {
           return false;
         }
@@ -38,11 +42,15 @@ class LaunchdarklyFlutter {
         return true;
 
       case 'callbackAllFlagsListener':
+        if (call.arguments == null) {
+          return false;
+        }
+
         if (!call.arguments.containsKey('flagKeys')) {
           return false;
         }
 
-        List<String> flagKeys = call.arguments['flagKeys'];
+        List<String> flagKeys = List<String>.from(call.arguments['flagKeys']);
 
         if (allFlagsListeners.isEmpty) {
           return false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: launchdarkly_flutter
 description: This is an unofficial LaunchDarkly SDK for Flutter, for anyone willing to use LaunchDarkly in a Flutter app.
-version: 0.3.0
+version: 0.4.0
 homepage: https://github.com/andre-paraense/launchdarkly_flutter
 issue_tracker: https://github.com/andre-paraense/launchdarkly_flutter/issues
 

--- a/test/launchdarkly_flutter_test.dart
+++ b/test/launchdarkly_flutter_test.dart
@@ -143,6 +143,25 @@ void main() {
     expect(flagListeners[flagKey], callback);
   });
 
+  test(
+      'registerFeatureFlagListener registering flagKey that already exists with different callback',
+      () async {
+    String flagKey = 'flagKey';
+    Function(String) callback = (flagKey) {
+      return flagKey;
+    };
+
+    await launchdarklyFlutter.registerFeatureFlagListener(flagKey, callback);
+    expect(flagListeners[flagKey], callback);
+
+    Function(String) callback2 = (flagKey) {
+      return '';
+    };
+
+    await launchdarklyFlutter.registerFeatureFlagListener(flagKey, callback2);
+    expect(flagListeners[flagKey], callback2);
+  });
+
   test('unregisterFeatureFlagListener with flagKey null', () async {
     String flagKey = 'flagKey';
     Function(String) callback = (flagKey) {
@@ -283,6 +302,25 @@ void main() {
 
     await launchdarklyFlutter.registerAllFlagsListener(listenerId, callback);
     expect(allFlagsListeners[listenerId], callback);
+  });
+
+  test(
+      'registerAllFlagsListener registering listenerId that already exists with different callback',
+      () async {
+    String listenerId = 'listenerId';
+    Function(List<String>) callback = (flagKeys) {
+      return flagKeys;
+    };
+
+    await launchdarklyFlutter.registerAllFlagsListener(listenerId, callback);
+    expect(allFlagsListeners[listenerId], callback);
+
+    Function(List<String>) callback2 = (flagKeys) {
+      return '';
+    };
+
+    await launchdarklyFlutter.registerAllFlagsListener(listenerId, callback2);
+    expect(allFlagsListeners[listenerId], callback2);
   });
 
   test('unregisterAllFlagsListener with listenerId null', () async {


### PR DESCRIPTION
### Requirements

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

### Related issues
Issue #15 .

### Describe the solution you've provided

I have provided access to the all flags listener in the Android SDK and iOS SDK through platform channel implementations.

### Describe alternatives you've considered

An alternative would have been to provide this through REST API channels, but this is not the way things have been done in this plugin - preferring to go with platform channels here.

### Additional context

N/A

### How to test?

Run the example app with your keys and have a go.

### Future works

No more in this direction! :)
