### PR TITLE
Add custom attributes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ try {
 }
 ```
 
+### Custom attributes
+
+You can pass custom attributes using `custom` argument in `init` method, e.g.:
+
+```dart
+final customAttrs = {
+  'string': 'value',
+  'boolean': true,
+  'number': 10,
+};
+await launchdarklyFlutter.init(mobileKey, userId, custom: customAttrs);
+```
+
+Your custom attributes map should have keys of type `String` and values of type `String | bool | number` (for deleting an attribute remove the key or set value to `null`).
+
 ## Not supported yet
 
 Check LaunchDarkly's [documentation](https://docs.launchdarkly.com) for more information on the features not yet supported. We are slowly and iteratively adding more features as we use them in our own projects. You are welcome to [contribute](CONTRIBUTING.md).

--- a/android/src/main/java/com/oakam/launchdarkly_flutter/LaunchdarklyFlutterPlugin.java
+++ b/android/src/main/java/com/oakam/launchdarkly_flutter/LaunchdarklyFlutterPlugin.java
@@ -101,20 +101,31 @@ public class LaunchdarklyFlutterPlugin implements FlutterPlugin, ActivityAware, 
               .setMobileKey(mobileKey)
               .build();
 
-      LDUser user = null;
+      LDUser.Builder userBuilder = null;
 
       if(call.hasArgument("userKey")) {
         String userKey = call.argument("userKey");
 
-        user = new LDUser.Builder(userKey)
-                .build();
+        userBuilder = new LDUser.Builder(userKey);
       }else {
-        user = new LDUser.Builder("")
-                .anonymous(true)
-                .build();
+        userBuilder = new LDUser.Builder("").anonymous(true);
       }
 
-      ldClient = LDClient.init(activity.getApplication(), ldConfig, user, 5);
+      Map<String, Object> custom = call.argument("custom");
+      if (custom != null) {
+        for (String key : custom.keySet()) {
+          final Object value = custom.get(key);
+          if (value instanceof String) {
+            userBuilder.custom(key, (String) value);
+          } else if (value instanceof Number) {
+            userBuilder.custom(key, (Number) value);
+          } else if (value instanceof Boolean) {
+            userBuilder.custom(key, (Boolean) value);
+          }
+        }
+      }
+
+      ldClient = LDClient.init(activity.getApplication(), ldConfig, userBuilder.build(), 5);
 
       result.success(true);
     } else if (call.method.equals("boolVariation")) {

--- a/example/README.md
+++ b/example/README.md
@@ -32,3 +32,18 @@ try {
 ```
 
 Replace `FLAG_KEY` with your flag key.
+
+### Custom attributes
+
+You can pass custom attributes using `custom` argument in `init` method, e.g.:
+
+```dart
+final customAttrs = {
+  'string': 'value',
+  'boolean': true,
+  'number': 10,
+};
+await launchdarklyFlutter.init(mobileKey, userId, custom: customAttrs);
+```
+
+Your custom attributes map should have keys of type `String` and values of type `String | bool | number` (for deleting an attribute remove the key or set value to `null`).

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,6 @@
-import 'package:flutter/material.dart';
 import 'dart:async';
+
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:launchdarkly_flutter/launchdarkly_flutter.dart';
 
@@ -32,9 +33,14 @@ class _MyAppState extends State<MyApp> {
     // Platform messages may fail, so we use a try/catch PlatformException.
 
     launchdarklyFlutter = LaunchdarklyFlutter();
+    final customAttrs = {
+      'string': 'value',
+      'boolean': true,
+      'number': 10,
+    };
 
     try {
-      await launchdarklyFlutter.init(mobileKey, userId);
+      await launchdarklyFlutter.init(mobileKey, userId, custom: customAttrs);
     } on PlatformException {}
   }
 
@@ -88,7 +94,7 @@ class _MyAppState extends State<MyApp> {
                     ? 'Unregister listener'
                     : 'Register listener'),
               ),
-              SizedBox(height: 30.0,),
+              SizedBox(height: 30.0),
               RaisedButton(
                 onPressed: () async {
                   _verifyAllFlags([]);
@@ -114,7 +120,8 @@ class _MyAppState extends State<MyApp> {
                       setState(() {
                         _listenerAllFlagsRegistered = true;
                       });
-                      await launchdarklyFlutter.registerAllFlagsListener('allFlags', _verifyAllFlags);
+                      await launchdarklyFlutter.registerAllFlagsListener(
+                          'allFlags', _verifyAllFlags);
                     } on PlatformException {
                       setState(() {
                         _listenerAllFlagsRegistered = false;

--- a/ios/Classes/SwiftLaunchdarklyFlutterPlugin.swift
+++ b/ios/Classes/SwiftLaunchdarklyFlutterPlugin.swift
@@ -43,7 +43,8 @@ import LaunchDarkly
             
         }else{
             
-            let user = LDUser(key: userKey)
+            var user = LDUser(key: userKey)
+            user.custom = arguments["custom"] as? [String: Any]
             LDClient.shared.startCompleteWhenFlagsReceived(config: config, user: user)
         }
         

--- a/lib/launchdarkly_flutter.dart
+++ b/lib/launchdarkly_flutter.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 
@@ -75,13 +76,23 @@ class LaunchdarklyFlutter {
   /// The userKey should also uniquely identify each user. You can use a primary key, an e-mail address,
   /// or a hash, as long as the same user always has the same key. We recommend using a hash if possible.
   /// You can also distinguish logged-in users from anonymous users in the SDK by leaving the userKey parameter null.
-  Future<bool> init(String mobileKey, String userKey) async {
+  /// You can pass custom arguments in [custom] map.
+  Future<bool> init(
+    String mobileKey,
+    String userKey, {
+    Map<String, dynamic> custom,
+  }) async {
     if (userKey == null) {
-      return await _channel
-          .invokeMethod('init', <String, dynamic>{'mobileKey': mobileKey});
+      return await _channel.invokeMethod('init', <String, dynamic>{
+        'mobileKey': mobileKey,
+        'custom': custom,
+      });
     } else {
-      return await _channel.invokeMethod('init',
-          <String, dynamic>{'mobileKey': mobileKey, 'userKey': userKey});
+      return await _channel.invokeMethod('init', <String, dynamic>{
+        'mobileKey': mobileKey,
+        'userKey': userKey,
+        'custom': custom,
+      });
     }
   }
 

--- a/test/launchdarkly_flutter_test.dart
+++ b/test/launchdarkly_flutter_test.dart
@@ -90,8 +90,17 @@ void main() {
   });
 
   test('init with all arguments', () async {
-    final result = await launchdarklyFlutter
-        .init('MOBILE_KEY', 'USER_ID', custom: {'custom': 'value'});
+    final customValues = {
+      'string': 'value',
+      'boolean': true,
+      'number': 10,
+      'null': null,
+    };
+    final result = await launchdarklyFlutter.init(
+      'MOBILE_KEY',
+      'USER_ID',
+      custom: customValues,
+    );
     expect(result, true);
   });
 

--- a/test/launchdarkly_flutter_test.dart
+++ b/test/launchdarkly_flutter_test.dart
@@ -85,8 +85,14 @@ void main() {
     expect(await launchdarklyFlutter.init('MOBILE_KEY', null), true);
   });
 
-  test('init with all arguments', () async {
+  test('init with mobile key and user', () async {
     expect(await launchdarklyFlutter.init('MOBILE_KEY', 'USER_ID'), true);
+  });
+
+  test('init with all arguments', () async {
+    final result = await launchdarklyFlutter
+        .init('MOBILE_KEY', 'USER_ID', custom: {'custom': 'value'});
+    expect(result, true);
   });
 
   test('boolVariation with no fallback', () async {


### PR DESCRIPTION
### Requirements

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

### Related issues

Fixes #19 

### Describe the solution you've provided

Added optional `custom` argument to `init` method.

### Describe alternatives you've considered

No.

### Additional context

No.

### How to test?

Pass `Map<String, dynamic> custom` argument to `init` method (e.g. `{'custom': 'value'}`). Check that the corresponding user in LD has this custom attribute set.

### Future works

1. Maybe we should enforce validation for custom parameters. For Android, it checks value types and calls overloaded `custom` methods; if values are of the wrong type it ignores the value at all. For iOS, it just passes the argument as `[String: Any]?` to user data.
2. In Android, we always have user builder, so we pass custom attributes always as well. In iOS, we only create user object if the user key is passed, so custom attributes are only set for an authenticated user. Maybe we should unify this behavior, either by ignoring custom attributes in Android for an anonymous user or by always creating user object in iOS (but it will require creating user key as well).
