### PR TITLE
Update platforms key introduced in Flutter 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.0
+## 0.5.1
 
 * Support for custom attributes (thanks to Kirill Bubochkin @ookami-kb !)
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.oakam.launchdarkly_flutter'
-version '0.5.0'
+version '0.5.1'
 
 buildscript {
     repositories {

--- a/ios/launchdarkly_flutter.podspec
+++ b/ios/launchdarkly_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'launchdarkly_flutter'
-  s.version          = '0.5.0'
+  s.version          = '0.5.1'
   s.summary          = 'A Flutter LaunchDarkly SDK.'
   s.description      = <<-DESC
 This is an unofficial LaunchDarkly SDK for Flutter, for anyone willing to use LaunchDarkly in a Flutter app.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,12 @@
 name: launchdarkly_flutter
 description: This is a LaunchDarkly SDK for Flutter, for anyone willing to use LaunchDarkly in a Flutter app.
-version: 0.5.0
+version: 0.5.1
 homepage: https://github.com/andre-paraense/launchdarkly_flutter
 issue_tracker: https://github.com/andre-paraense/launchdarkly_flutter/issues
 
 environment:
   sdk: ">=2.1.0 <3.0.0"
+  flutter: ">=1.12.0 <2.0.0"
 
 dependencies:
   flutter:
@@ -17,5 +18,9 @@ dev_dependencies:
 
 flutter:
   plugin:
-    androidPackage: com.oakam.launchdarkly_flutter
-    pluginClass: LaunchdarklyFlutterPlugin
+    platforms:
+      android:
+        package: com.oakam.launchdarkly_flutter
+        pluginClass: LaunchdarklyFlutterPlugin
+      ios:
+        pluginClass: LaunchdarklyFlutterPlugin


### PR DESCRIPTION
Just updating keys in `pubspec.yaml` according to the publish mechanism.
