### PR TITLE
[Android] Handle long type when parsing custom attributes

### DIFF
--- a/android/src/main/java/com/oakam/launchdarkly_flutter/LaunchdarklyFlutterPlugin.java
+++ b/android/src/main/java/com/oakam/launchdarkly_flutter/LaunchdarklyFlutterPlugin.java
@@ -105,11 +105,13 @@ public class LaunchdarklyFlutterPlugin implements FlutterPlugin, ActivityAware, 
         final Object value = custom.get(key);
         if (value instanceof String) {
           userBuilder.custom(key, (String) value);
+        } else if (value instanceof Long) {
+            userBuilder.custom(key, (Long) value);
         } else if (value instanceof Integer) {
           userBuilder.custom(key, (Integer) value);
         } else if (value instanceof Double) {
           userBuilder.custom(key, (Double) value);
-       } else if (value instanceof Boolean) {
+        } else if (value instanceof Boolean) {
           userBuilder.custom(key, (Boolean) value);
         }
       }


### PR DESCRIPTION
### Requirements

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

### Related issues

While testing, we noticed that `timestamp` in milliseconds since epoch wasn't sent to LaunchDarkly when running on Android. This happens due to `long` type not being handled when parsing `custom` attributes.

Unlike Dart, Java has four integer types: `byte`, `short`, `int` and `long`. Long integers like a timestamp won't fit `int` and will be converted to a `long` rather than an `int`. Meaning, when `identify` / `init` is called, those attributes will be omitted from the resulting custom attributes map and won't be sent to LaunchDarkly.

### Describe the solution you've provided

I've added another if-else branch to handle `long` type.

### Additional context

[Platform channel data types support and codecs](https://flutter.dev/docs/development/platform-integration/platform-channels#codec)

### How to test?

The issue can be reproduced with this code:
```
  import 'package:launchdarkly_flutter/launchdarkly_flutter.dart';
  ...

  Future<void> init() async {
    await LaunchdarklyFlutter().init(
      'your_api_key',
      'test_user',
      custom: {
        'timestamp': DateTime.now().toUtc().millisecondsSinceEpoch,
      },
    );
  }
```

Thank you for the great package! 