### PR TITLE
Private User Attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ try {
 ```
 Be sure to use a mobile key from your [Environments](https://app.launchdarkly.com/settings#/environments) page. Never embed a server-side SDK key into a mobile application. Check LaunchDarkly's [documentation](https://docs.launchdarkly.com) for in-depth instructions on configuring and using LaunchDarkly.
 
+Optionally, you can choose to pass additional configuration parameters like:
+```dart
+await launchdarklyFlutter.init('YOUR_MOBILE_KEY', 'USER_ID', config: LaunchDarklyConfig(allAttributesPrivate: false,));
+```
+
 Give some time for the initialization process to fetch new flags values (or risk getting the defaults right away), and check them:
 
 ```dart
@@ -64,20 +69,45 @@ try {
 }
 ```
 
-### Custom attributes
+### Built-in user attributes and custom attributes
 
-You can pass custom attributes using `custom` argument in `init` method, e.g.:
+LaunchDarkly includes a set of built-in attributes for users, like `key`, `firstName`, `lastName`, `email`, etc. as well as allows to use custom attributes.
+For details, please refer to [Understanding user attributes](https://docs.launchdarkly.com/home/users/attributes#understanding-user-attributes).
+
+Both built-in and custom user attributes can be specified via a single `attributes` map. The plugin will recognize built-in and custom attributes and passes them to LaunchDarkly SDK properly. 
 
 ```dart
-final customAttrs = {
+final attrs = {
+  'email': 'example@example.com',
   'string': 'value',
   'boolean': true,
   'number': 10,
 };
-await launchdarklyFlutter.init(mobileKey, userId, custom: customAttrs);
+await launchdarklyFlutter.init(mobileKey, userId, custom: attrs);
 ```
 
 Your custom attributes map should have keys of type `String` and values of type `String | bool | number` (for deleting an attribute remove the key or set value to `null`).
+
+### Private attributes
+
+You may not want to send all attributes back to LaunchDarkly due to the security or data protection requirements of your organization.
+LaunchDarkly's private user attributes feature lets you choose which attributes get sent back to LaunchDarkly without sacrificing the ability to target user segments.
+
+- You can mark all attributes private globally in the `LaunchDarklyConfig` configuration object.
+- You can mark specific attributes private by name globally in the `LaunchDarklyConfig` configuration object.
+- You can mark specific attributes private by name for individual users when you call `identify` (see below).
+
+```dart
+final privateAttrs = {
+  'email': 'example@example.com',
+  'string': 'value',
+  'boolean': true,
+  'number': 10,
+};
+await launchdarklyFlutter.init(mobileKey, userId, privateAttributes: privateAttrs);
+```
+
+More about private user attributes can be found [here](https://docs.launchdarkly.com/home/users/attributes#creating-private-user-attributes).
 
 ### Changing the User Context
 
@@ -86,7 +116,7 @@ If your app is used by multiple users on a single device, you may want to change
 You can use the identify method to switch user contexts:
 
 ```dart
-await launchdarklyFlutter.identify(userId, custom: customAttrs);
+await launchdarklyFlutter.identify(userId, attributes: attributes, privateAttributes: privateAttributes);
 ```
 
 ## Not supported yet

--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ In addtion to the built-in user attributes, you can pass your own custom attribu
 
 ```dart
 final attrs = {
-  'email': 'example@example.com',
   'string': 'value',
   'boolean': true,
   'number': 10,
@@ -105,7 +104,7 @@ LaunchDarkly's private user attributes feature lets you choose which attributes 
 
 - You can mark all attributes private globally in the `LaunchDarklyConfig` configuration object.
 - You can mark specific attributes private by name globally in the `LaunchDarklyConfig` configuration object.
-- You can mark specific attributes private by name for individual users when you call `identify` (see below).
+- You can mark specific attributes private by name for individual users when you call `init` / `identify` (see below).
 
 ```dart
 final user = LaunchDarklyUser(

--- a/README.md
+++ b/README.md
@@ -69,12 +69,22 @@ try {
 }
 ```
 
-### Built-in user attributes and custom attributes
+### Built-in user attributes
 
-LaunchDarkly includes a set of built-in attributes for users, like `key`, `firstName`, `lastName`, `email`, etc. as well as allows to use custom attributes.
+LaunchDarkly includes a set of built-in attributes for users, like `key`, `firstName`, `lastName`, `email`.
 For details, please refer to [Understanding user attributes](https://docs.launchdarkly.com/home/users/attributes#understanding-user-attributes).
 
-Both built-in and custom user attributes can be specified via a single `attributes` map. The plugin will recognize built-in and custom attributes and passes them to LaunchDarkly SDK properly. 
+The built-in user attributes can be set via parameter `user` of `LaunchDarklyUser` type:
+```dart
+final user = LaunchDarklyUser(
+  email: 'example@example.com',
+);
+await launchdarklyFlutter.init(mobileKey, userId, user: user);
+```
+
+### Custom attributes
+
+In addtion to the built-in user attributes, you can pass your own custom attributes.
 
 ```dart
 final attrs = {
@@ -98,13 +108,15 @@ LaunchDarkly's private user attributes feature lets you choose which attributes 
 - You can mark specific attributes private by name for individual users when you call `identify` (see below).
 
 ```dart
+final user = LaunchDarklyUser(
+  privateEmail: 'example@example.com',
+);
 final privateAttrs = {
-  'email': 'example@example.com',
   'string': 'value',
   'boolean': true,
   'number': 10,
 };
-await launchdarklyFlutter.init(mobileKey, userId, privateAttributes: privateAttrs);
+await launchdarklyFlutter.init(mobileKey, userId, user: user, privateCustom: privateAttrs);
 ```
 
 More about private user attributes can be found [here](https://docs.launchdarkly.com/home/users/attributes#creating-private-user-attributes).
@@ -116,7 +128,7 @@ If your app is used by multiple users on a single device, you may want to change
 You can use the identify method to switch user contexts:
 
 ```dart
-await launchdarklyFlutter.identify(userId, attributes: attributes, privateAttributes: privateAttributes);
+await launchdarklyFlutter.identify(userId, user: user, custom: custom, privateCustom: privateCustom);
 ```
 
 ## Not supported yet

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,4 +35,5 @@ android {
 
 dependencies {
     implementation 'com.launchdarkly:launchdarkly-android-client-sdk:3.0.0'
+    testImplementation 'junit:junit:4.13.1'
 }

--- a/android/src/main/java/com/oakam/launchdarkly_flutter/LaunchdarklyFlutterPlugin.java
+++ b/android/src/main/java/com/oakam/launchdarkly_flutter/LaunchdarklyFlutterPlugin.java
@@ -93,7 +93,8 @@ public class LaunchdarklyFlutterPlugin implements FlutterPlugin, ActivityAware, 
 
   }
 
-  private LDUser createUser(@NonNull MethodCall call) {
+  @VisibleForTesting
+  LDUser createUser(@NonNull MethodCall call) {
     LDUser.Builder userBuilder;
 
     if (call.hasArgument("userKey")) {
@@ -308,7 +309,7 @@ public class LaunchdarklyFlutterPlugin implements FlutterPlugin, ActivityAware, 
   }
 
   @VisibleForTesting
-  static void populateCustomAttributes(LDUser.Builder builder, Map<String, Object> attributes, List<String> privateAttributeKeys) {
+  void populateCustomAttributes(LDUser.Builder builder, Map<String, Object> attributes, List<String> privateAttributeKeys) {
     for (String key : attributes.keySet()) {
       final Object value = attributes.get(key);
       final boolean isPrivate = privateAttributeKeys.contains(key);
@@ -321,7 +322,7 @@ public class LaunchdarklyFlutterPlugin implements FlutterPlugin, ActivityAware, 
   }
 
   @VisibleForTesting
-  static void populateBuiltInAttributes(LDUser.Builder builder, Map<String, String> attributes, List<String> privateAttributeKeys) {
+  void populateBuiltInAttributes(LDUser.Builder builder, Map<String, String> attributes, List<String> privateAttributeKeys) {
     final String secondaryKey = attributes.get("secondaryKey");
     if (privateAttributeKeys.contains("secondaryKey")) {
       builder.privateSecondary(secondaryKey);

--- a/android/src/main/java/com/oakam/launchdarkly_flutter/LaunchdarklyFlutterPlugin.java
+++ b/android/src/main/java/com/oakam/launchdarkly_flutter/LaunchdarklyFlutterPlugin.java
@@ -105,11 +105,13 @@ public class LaunchdarklyFlutterPlugin implements FlutterPlugin, ActivityAware, 
         final Object value = custom.get(key);
         if (value instanceof String) {
           userBuilder.custom(key, (String) value);
+        } else if (value instanceof Long) {
+            userBuilder.custom(key, (Long) value);
         } else if (value instanceof Integer) {
           userBuilder.custom(key, (Integer) value);
         } else if (value instanceof Double) {
           userBuilder.custom(key, (Double) value);
-       } else if (value instanceof Boolean) {
+        } else if (value instanceof Boolean) {
           userBuilder.custom(key, (Boolean) value);
         }
       }

--- a/android/src/main/java/com/oakam/launchdarkly_flutter/LaunchdarklyFlutterPlugin.java
+++ b/android/src/main/java/com/oakam/launchdarkly_flutter/LaunchdarklyFlutterPlugin.java
@@ -6,15 +6,19 @@ import android.os.Looper;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 
+import com.launchdarkly.sdk.LDUser;
 import com.launchdarkly.sdk.LDValue;
+import com.launchdarkly.sdk.UserAttribute;
 import com.launchdarkly.sdk.android.FeatureFlagChangeListener;
 import com.launchdarkly.sdk.android.LDAllFlagsListener;
 import com.launchdarkly.sdk.android.LDClient;
 import com.launchdarkly.sdk.android.LDConfig;
-import com.launchdarkly.sdk.LDUser;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -99,22 +103,19 @@ public class LaunchdarklyFlutterPlugin implements FlutterPlugin, ActivityAware, 
       userBuilder = new LDUser.Builder(UUID.randomUUID().toString()).anonymous(true);
     }
 
+    List<String> privateAttributes = call.argument("privateAttributes");
+    if (privateAttributes == null) {
+      privateAttributes = new ArrayList<>();
+    }
+
+    Map<String, String> userMap = call.argument("user");
+    if (userMap != null) {
+      populateBuiltInAttributes(userBuilder, userMap, privateAttributes);
+    }
+
     Map<String, Object> custom = call.argument("custom");
     if (custom != null) {
-      for (String key : custom.keySet()) {
-        final Object value = custom.get(key);
-        if (value instanceof String) {
-          userBuilder.custom(key, (String) value);
-        } else if (value instanceof Long) {
-            userBuilder.custom(key, (Long) value);
-        } else if (value instanceof Integer) {
-          userBuilder.custom(key, (Integer) value);
-        } else if (value instanceof Double) {
-          userBuilder.custom(key, (Double) value);
-        } else if (value instanceof Boolean) {
-          userBuilder.custom(key, (Boolean) value);
-        }
-      }
+      populateCustomAttributes(userBuilder, custom, privateAttributes);
     }
 
     return userBuilder.build();
@@ -132,9 +133,28 @@ public class LaunchdarklyFlutterPlugin implements FlutterPlugin, ActivityAware, 
         return;
       }
 
-      LDConfig ldConfig = new LDConfig.Builder()
-              .mobileKey(mobileKey)
-              .build();
+      LDConfig.Builder ldConfigBuilder = new LDConfig.Builder()
+              .mobileKey(mobileKey);
+
+      Map<String, Object> config = call.argument("config");
+      if (config != null) {
+        final Object allAttributesPrivate = config.get("allAttributesPrivate");
+        if (allAttributesPrivate instanceof Boolean && (Boolean) allAttributesPrivate) {
+          ldConfigBuilder.allAttributesPrivate();
+        }
+        final Object privateAttributes = config.get("privateAttributes");
+        if (privateAttributes instanceof List) {
+          final List<UserAttribute> userAttributes = new ArrayList<>();
+          for (Object privateAttribute : (List) privateAttributes) {
+            if (privateAttribute instanceof String) {
+              userAttributes.add(UserAttribute.forName((String) privateAttribute));
+            }
+          }
+          ldConfigBuilder.privateAttributes(userAttributes.toArray(new UserAttribute[0]));
+        }
+      }
+
+      LDConfig ldConfig = ldConfigBuilder.build();
 
       ldClient = LDClient.init(activity.getApplication(), ldConfig, createUser(call), 5);
 
@@ -257,5 +277,98 @@ public class LaunchdarklyFlutterPlugin implements FlutterPlugin, ActivityAware, 
   private void setupChannel(BinaryMessenger messenger) {
     channel = new MethodChannel(messenger, "launchdarkly_flutter");
     channel.setMethodCallHandler(this);
+  }
+
+  private static void populatePrivateCustomAttribute(LDUser.Builder builder, String key, Object value) {
+    if (value instanceof String) {
+      builder.privateCustom(key, (String) value);
+    } else if (value instanceof Long) {
+      builder.privateCustom(key, (Long) value);
+    } else if (value instanceof Integer) {
+      builder.privateCustom(key, (Integer) value);
+    } else if (value instanceof Double) {
+      builder.privateCustom(key, (Double) value);
+    } else if (value instanceof Boolean) {
+      builder.privateCustom(key, (Boolean) value);
+    }
+  }
+
+  private static void populateCustomAttribute(LDUser.Builder builder, String key, Object value) {
+    if (value instanceof String) {
+      builder.custom(key, (String) value);
+    } else if (value instanceof Long) {
+      builder.custom(key, (Long) value);
+    } else if (value instanceof Integer) {
+      builder.custom(key, (Integer) value);
+    } else if (value instanceof Double) {
+      builder.custom(key, (Double) value);
+    } else if (value instanceof Boolean) {
+      builder.custom(key, (Boolean) value);
+    }
+  }
+
+  @VisibleForTesting
+  static void populateCustomAttributes(LDUser.Builder builder, Map<String, Object> attributes, List<String> privateAttributeKeys) {
+    for (String key : attributes.keySet()) {
+      final Object value = attributes.get(key);
+      final boolean isPrivate = privateAttributeKeys.contains(key);
+      if (isPrivate) {
+        populatePrivateCustomAttribute(builder, key, value);
+      } else {
+        populateCustomAttribute(builder, key, value);
+      }
+    }
+  }
+
+  @VisibleForTesting
+  static void populateBuiltInAttributes(LDUser.Builder builder, Map<String, String> attributes, List<String> privateAttributeKeys) {
+    final String secondaryKey = attributes.get("secondaryKey");
+    if (privateAttributeKeys.contains("secondaryKey")) {
+      builder.privateSecondary(secondaryKey);
+    } else {
+      builder.secondary(secondaryKey);
+    }
+    final String ip = attributes.get("ip");
+    if (privateAttributeKeys.contains("ip")) {
+      builder.privateIp(ip);
+    } else {
+      builder.ip(ip);
+    }
+    final String country = attributes.get("country");
+    if (privateAttributeKeys.contains("country")) {
+      builder.privateCountry(country);
+    } else {
+      builder.country(country);
+    }
+    final String avatar = attributes.get("avatar");
+    if (privateAttributeKeys.contains("avatar")) {
+      builder.privateAvatar(avatar);
+    } else {
+      builder.avatar(avatar);
+    }
+    final String name = attributes.get("name");
+    if (privateAttributeKeys.contains("name")) {
+      builder.privateName(name);
+    } else {
+      builder.name(name);
+    }
+    final String email = attributes.get("email");
+    if (privateAttributeKeys.contains("email")) {
+      builder.privateEmail(email);
+    } else {
+      builder.email(email);
+    }
+    final String firstName = attributes.get("firstName");
+    if (privateAttributeKeys.contains("firstName")) {
+      builder.privateFirstName(firstName);
+    } else {
+      builder.firstName(firstName);
+    }
+    final String lastName = attributes.get("lastName");
+    if (privateAttributeKeys.contains("lastName")) {
+      builder.privateLastName(lastName);
+    } else {
+      builder.lastName(lastName);
+    }
   }
 }

--- a/android/src/main/java/com/oakam/launchdarkly_flutter/LaunchdarklyFlutterPlugin.java
+++ b/android/src/main/java/com/oakam/launchdarkly_flutter/LaunchdarklyFlutterPlugin.java
@@ -323,8 +323,8 @@ public class LaunchdarklyFlutterPlugin implements FlutterPlugin, ActivityAware, 
 
   @VisibleForTesting
   void populateBuiltInAttributes(LDUser.Builder builder, Map<String, String> attributes, List<String> privateAttributeKeys) {
-    final String secondaryKey = attributes.get("secondaryKey");
-    if (privateAttributeKeys.contains("secondaryKey")) {
+    final String secondaryKey = attributes.get("secondary");
+    if (privateAttributeKeys.contains("secondary")) {
       builder.privateSecondary(secondaryKey);
     } else {
       builder.secondary(secondaryKey);

--- a/android/src/test/java/com/oakam/launchdarkly_flutter/LaunchdarklyFlutterPluginTest.java
+++ b/android/src/test/java/com/oakam/launchdarkly_flutter/LaunchdarklyFlutterPluginTest.java
@@ -1,0 +1,183 @@
+package com.oakam.launchdarkly_flutter;
+
+import com.launchdarkly.sdk.LDUser;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.flutter.plugin.common.MethodCall;
+
+public class LaunchdarklyFlutterPluginTest {
+
+    private final LaunchdarklyFlutterPlugin plugin = new LaunchdarklyFlutterPlugin();
+
+    @Test
+    public void testUserAttributes() {
+        final String userId = "testUserID";
+        final String secondaryKey = "testSecondaryKey";
+        final String avatar = "testAvatarUrl";
+        final String country = "Test County";
+        final String ip = "localhost";
+        final String email = "test@test.com";
+        final String name = "Test Full Name";
+        final String firstName = "Test First Name";
+        final String lastName = "Test Last Name";
+
+        final LDUser expected = new LDUser.Builder(userId)
+                .secondary(secondaryKey)
+                .avatar(avatar)
+                .country(country)
+                .ip(ip)
+                .email(email)
+                .firstName(firstName)
+                .lastName(lastName)
+                .name(name)
+                .build();
+
+        final LDUser.Builder builder = new LDUser.Builder(userId);
+
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("secondaryKey", secondaryKey);
+        attributes.put("avatar", avatar);
+        attributes.put("country", country);
+        attributes.put("ip", ip);
+        attributes.put("email", email);
+        attributes.put("name", name);
+        attributes.put("lastName", lastName);
+        attributes.put("firstName", firstName);
+
+        plugin.populateBuiltInAttributes(builder, attributes, new ArrayList<String>());
+
+        Assert.assertEquals(expected, builder.build());
+    }
+
+    @Test
+    public void testPrivateUserAttributes() {
+        final String userId = "testUserID";
+        final String secondaryKey = "testSecondaryKey";
+        final String avatar = "testAvatarUrl";
+        final String country = "Test County";
+        final String ip = "localhost";
+        final String email = "test@test.com";
+        final String name = "Test Full Name";
+        final String firstName = "Test First Name";
+        final String lastName = "Test Last Name";
+
+        final LDUser expected = new LDUser.Builder(userId)
+                .privateSecondary(secondaryKey)
+                .privateAvatar(avatar)
+                .privateCountry(country)
+                .privateIp(ip)
+                .privateEmail(email)
+                .privateFirstName(firstName)
+                .privateLastName(lastName)
+                .privateName(name)
+                .build();
+
+        final LDUser.Builder builder = new LDUser.Builder(userId);
+
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("secondaryKey", secondaryKey);
+        attributes.put("avatar", avatar);
+        attributes.put("country", country);
+        attributes.put("ip", ip);
+        attributes.put("email", email);
+        attributes.put("name", name);
+        attributes.put("lastName", lastName);
+        attributes.put("firstName", firstName);
+
+        plugin.populateBuiltInAttributes(builder, attributes, new ArrayList<>(attributes.keySet()));
+
+        Assert.assertEquals(expected, builder.build());
+    }
+
+    @Test
+    public void testCustomAttributes() {
+        final String userId = "testUserID";
+        final String string = "string";
+        final int integer = 10;
+        final long longNumber = 10L;
+        final double doubleNumber = 2.0;
+
+        final LDUser expected = new LDUser.Builder(userId)
+                .custom("string", string)
+                .custom("integer", integer)
+                .custom("long", longNumber)
+                .custom("double", doubleNumber)
+                .build();
+
+        final LDUser.Builder builder = new LDUser.Builder(userId);
+
+        final Map<String, Object> attributes = new HashMap<>();
+        attributes.put("string", string);
+        attributes.put("integer", integer);
+        attributes.put("long", longNumber);
+        attributes.put("double", doubleNumber);
+
+        plugin.populateCustomAttributes(builder, attributes, new ArrayList<String>());
+
+        Assert.assertEquals(expected, builder.build());
+    }
+
+    @Test
+    public void testPrivateCustomAttributes() {
+        final String userId = "testUserID";
+        final String string = "string";
+        final int integer = 10;
+        final long longNumber = 10L;
+        final double doubleNumber = 2.0;
+
+        final LDUser expected = new LDUser.Builder(userId)
+                .privateCustom("string", string)
+                .privateCustom("integer", integer)
+                .privateCustom("long", longNumber)
+                .privateCustom("double", doubleNumber)
+                .build();
+
+        final LDUser.Builder builder = new LDUser.Builder(userId);
+
+        final Map<String, Object> attributes = new HashMap<>();
+        attributes.put("string", string);
+        attributes.put("integer", integer);
+        attributes.put("long", longNumber);
+        attributes.put("double", doubleNumber);
+
+        plugin.populateCustomAttributes(builder, attributes, new ArrayList<>(attributes.keySet()));
+
+        Assert.assertEquals(expected, builder.build());
+    }
+
+    @Test
+    public void testCreateUser() {
+        final String userId = "testUserID";
+        final String email = "test@test.com";
+        final String customAttr = "customAttr";
+
+        final LDUser expected = new LDUser.Builder(userId)
+                .anonymous(false)
+                .email(email)
+                .privateCustom("privateCustom", customAttr)
+                .build();
+
+        final Map<String, String> userAttributes = new HashMap<>();
+        userAttributes.put("email", email);
+
+        final Map<String, Object> custom = new HashMap<>();
+        custom.put("privateCustom", customAttr);
+
+        final Map<String, Object> arguments = new HashMap<>();
+        arguments.put("userKey", userId);
+        arguments.put("custom", custom);
+        arguments.put("user", userAttributes);
+        arguments.put("privateAttributes", new ArrayList<>(custom.keySet()));
+
+        final MethodCall methodCall = new MethodCall("identify", arguments);
+        final LDUser actual = plugin.createUser(methodCall);
+
+        Assert.assertEquals(expected, actual);
+    }
+}

--- a/android/src/test/java/com/oakam/launchdarkly_flutter/LaunchdarklyFlutterPluginTest.java
+++ b/android/src/test/java/com/oakam/launchdarkly_flutter/LaunchdarklyFlutterPluginTest.java
@@ -41,7 +41,7 @@ public class LaunchdarklyFlutterPluginTest {
         final LDUser.Builder builder = new LDUser.Builder(userId);
 
         final Map<String, String> attributes = new HashMap<>();
-        attributes.put("secondaryKey", secondaryKey);
+        attributes.put("secondary", secondaryKey);
         attributes.put("avatar", avatar);
         attributes.put("country", country);
         attributes.put("ip", ip);
@@ -81,7 +81,7 @@ public class LaunchdarklyFlutterPluginTest {
         final LDUser.Builder builder = new LDUser.Builder(userId);
 
         final Map<String, String> attributes = new HashMap<>();
-        attributes.put("secondaryKey", secondaryKey);
+        attributes.put("secondary", secondaryKey);
         attributes.put("avatar", avatar);
         attributes.put("country", country);
         attributes.put("ip", ip);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:launchdarkly_flutter/launchdarkly_config.dart';
 import 'package:launchdarkly_flutter/launchdarkly_flutter.dart';
+import 'package:launchdarkly_flutter/launchdarkly_user.dart';
 
 void main() => runApp(MyApp());
 
@@ -24,8 +26,10 @@ class _MyAppState extends State<MyApp> {
   String flagKey = 'FLAG_KEY';
 
   final ldUser = LaunchDarklyUser(
-    privateEmail: 'example@example.com',
-  );
+      email: 'example@example.com',
+      // Private attributes are omitted from being sent to LaunchDarkly but remain targetable.
+      privateFirstName: "USER_FIRST_NAME",
+      privateLastName: "USER_LAST_NAME");
 
   @override
   void initState() {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -23,6 +23,10 @@ class _MyAppState extends State<MyApp> {
   String userId = 'USER_ID';
   String flagKey = 'FLAG_KEY';
 
+  final ldUser = LaunchDarklyUser(
+    privateEmail: 'example@example.com',
+  );
+
   @override
   void initState() {
     super.initState();
@@ -36,7 +40,16 @@ class _MyAppState extends State<MyApp> {
     launchdarklyFlutter = LaunchdarklyFlutter();
 
     try {
-      await launchdarklyFlutter.init(mobileKey, userId, custom: _customAttrs);
+      await launchdarklyFlutter.init(
+        mobileKey,
+        userId,
+        config: LaunchDarklyConfig(
+          allAttributesPrivate: false,
+          privateAttributes: {'email'},
+        ),
+        custom: attrs,
+        privateCustom: privateAttrs,
+      );
     } on PlatformException {}
   }
 
@@ -44,7 +57,8 @@ class _MyAppState extends State<MyApp> {
     final isLoggedIn = !_isLoggedIn;
     await launchdarklyFlutter.identify(
       isLoggedIn ? userId : null,
-      custom: _customAttrs,
+      custom: attrs,
+      privateCustom: privateAttrs,
     );
     setState(() => _isLoggedIn = isLoggedIn);
     _verifyFlag(flagKey);
@@ -200,8 +214,14 @@ class _MyAppState extends State<MyApp> {
   }
 }
 
-const _customAttrs = {
+const attrs = {
   'string': 'value',
   'boolean': true,
   'number': 10,
+};
+
+const privateAttrs = {
+  'privateString': 'value',
+  'privateBoolean': true,
+  'privateNumber': 10,
 };

--- a/ios/Classes/SwiftLaunchdarklyFlutterPlugin.swift
+++ b/ios/Classes/SwiftLaunchdarklyFlutterPlugin.swift
@@ -29,8 +29,19 @@ import LaunchDarkly
       isAnonymous = true
     }
     
+    let userAttributes = arguments["user"] as? [String:Any] ?? [:]
+    
     var user = LDUser(key: userKey)
     user.isAnonymous = isAnonymous
+    user.secondary = userAttributes["secondary"] as? String
+    user.country = userAttributes["country"] as? String
+    user.ipAddress = userAttributes["ip"] as? String
+    user.avatar = userAttributes["avatar"] as? String
+    user.name = userAttributes["name"] as? String
+    user.firstName = userAttributes["firstName"] as? String
+    user.lastName = userAttributes["lastName"] as? String
+    user.email = userAttributes["email"] as? String
+    user.privateAttributes = arguments["privateAttributes"] as? [String]
     user.custom = arguments["custom"] as? [String: Any]
     
     return user
@@ -48,7 +59,11 @@ import LaunchDarkly
             return
         }
         
-        let config = LDConfig(mobileKey: mobileKey ?? "")
+        let configArgs = arguments["config"] as? [String: Any] ?? [:]
+        
+        var config = LDConfig(mobileKey: mobileKey ?? "")
+        config.allUserAttributesPrivate = configArgs["allAttributesPrivate"] as? Bool ?? false
+        config.privateUserAttributes = configArgs["privateAttributes"] as? [String]
         
         LDClient.start(config: config, user: createUser(arguments: arguments), startWaitSeconds: 5) { timedOut in
             result(true)

--- a/lib/launch_darkly_extensions.dart
+++ b/lib/launch_darkly_extensions.dart
@@ -1,0 +1,25 @@
+part of "launchdarkly_flutter.dart";
+
+extension _LaunchDarklyUserSerializer on LaunchDarklyUser {
+  /// The method of serialization to a map.
+  /// Intended to use to pass over the MethodChannel.
+  Map<String, dynamic> toMap() => {
+        'secondary': secondaryKey,
+        'ip': ip,
+        'country': country,
+        'avatar': avatar,
+        'email': email,
+        'name': name,
+        'firstName': firstName,
+        'lastName': lastName,
+      };
+}
+
+extension _LaunchDarklyConfigSerializer on LaunchDarklyConfig {
+  /// The method of serialization to a map.
+  /// Intended to use to pass over the MethodChannel.
+  Map<String, dynamic> toMap() => {
+        'allAttributesPrivate': allAttributesPrivate,
+        'privateAttributes': privateAttributes.toList(),
+      };
+}

--- a/lib/launchdarkly_config.dart
+++ b/lib/launchdarkly_config.dart
@@ -1,0 +1,16 @@
+/// This class exposes advanced configuration options for LaunchDarkly client.
+class LaunchDarklyConfig {
+  /// Specifies that user attributes (other than the key) should be hidden from LaunchDarkly.
+  /// If this is set, all user attribute values will be private.
+  final bool allAttributesPrivate;
+  /// Marks a set of attributes private. Any users sent to LaunchDarkly with this configuration active will have attributes with these names removed.
+  /// This can also be specified on a per-user basis, please refer to [LaunchDarklyUser].
+  final Set<String> privateAttributes;
+
+  /// Constructor for creating a LaunchDarkly config.
+  /// All parameters are optional.
+  const LaunchDarklyConfig({
+    this.allAttributesPrivate = false,
+    this.privateAttributes = const {},
+  });
+}

--- a/lib/launchdarkly_flutter.dart
+++ b/lib/launchdarkly_flutter.dart
@@ -77,7 +77,7 @@ class LaunchDarklyUser {
         this.firstName = privateFirstName ?? firstName,
         this.lastName = privateLastName ?? lastName,
         this.privateAttributes = [
-          if (privateSecondaryKey != null) 'secondaryKey',
+          if (privateSecondaryKey != null) 'secondary',
           if (privateIp != null) 'ip',
           if (privateCountry != null) 'country',
           if (privateAvatar != null) 'avatar',
@@ -88,7 +88,7 @@ class LaunchDarklyUser {
         ];
 
   Map<String, dynamic> toMap() => {
-        'secondaryKey': secondaryKey,
+        'secondary': secondaryKey,
         'ip': ip,
         'country': country,
         'avatar': avatar,

--- a/lib/launchdarkly_flutter.dart
+++ b/lib/launchdarkly_flutter.dart
@@ -20,7 +20,7 @@ class LaunchDarklyConfig {
 
 /// A collection of attributes that can affect flag evaluation, usually corresponding to a user of your application.
 ///
-/// If you want to avoid sending personal information back to LaunchDarkly but keep the ability to target, you can configure those attributes as private.
+/// If you want to avoid sending personal information back to LaunchDarkly but keep the ability to target user segments, you can configure those attributes as private.
 /// Use `private`-prefixed counterparts for this purpose.
 class LaunchDarklyUser {
   /// Sets the secondary key for a user. This affects feature flag targeting as follows:

--- a/lib/launchdarkly_flutter.dart
+++ b/lib/launchdarkly_flutter.dart
@@ -2,102 +2,10 @@ import 'dart:async';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
+import 'package:launchdarkly_flutter/launchdarkly_config.dart';
+import 'package:launchdarkly_flutter/launchdarkly_user.dart';
 
-class LaunchDarklyConfig {
-  final bool allAttributesPrivate;
-  final Set<String> privateAttributes;
-
-  const LaunchDarklyConfig({
-    this.allAttributesPrivate = false,
-    this.privateAttributes = const {},
-  });
-
-  Map<String, dynamic> toMap() => {
-        'allAttributesPrivate': allAttributesPrivate,
-        'privateAttributes': privateAttributes.toList(),
-      };
-}
-
-/// A collection of attributes that can affect flag evaluation, usually corresponding to a user of your application.
-///
-/// If you want to avoid sending personal information back to LaunchDarkly but keep the ability to target user segments, you can configure those attributes as private.
-/// Use `private`-prefixed counterparts for this purpose.
-class LaunchDarklyUser {
-  /// Sets the secondary key for a user. This affects feature flag targeting as follows:
-  /// if you have chosen to bucket users by a specific attribute,
-  /// he secondary key (if set) is used to further distinguish between users who are otherwise identical according to that attribute.
-  final String? secondaryKey;
-
-  /// Sets the IP for a user.
-  final String? ip;
-
-  /// Set the country for a user.
-  final String? country;
-
-  /// Sets the user's avatar.
-  final String? avatar;
-
-  /// Sets the user's e-mail address.
-  final String? email;
-
-  /// Sets the user's full name.
-  final String? name;
-
-  /// Sets the user's first name.
-  final String? firstName;
-
-  /// Sets the user's last name.
-  final String? lastName;
-
-  final List<String> privateAttributes;
-
-  LaunchDarklyUser({
-    String? secondaryKey,
-    String? privateSecondaryKey,
-    String? ip,
-    String? privateIp,
-    String? country,
-    String? privateCountry,
-    String? avatar,
-    String? privateAvatar,
-    String? email,
-    String? privateEmail,
-    String? name,
-    String? privateName,
-    String? firstName,
-    String? privateFirstName,
-    String? lastName,
-    String? privateLastName,
-  })  : this.secondaryKey = privateSecondaryKey ?? secondaryKey,
-        this.ip = privateIp ?? ip,
-        this.country = privateCountry ?? country,
-        this.avatar = privateAvatar ?? avatar,
-        this.email = privateEmail ?? email,
-        this.name = privateName ?? name,
-        this.firstName = privateFirstName ?? firstName,
-        this.lastName = privateLastName ?? lastName,
-        this.privateAttributes = [
-          if (privateSecondaryKey != null) 'secondary',
-          if (privateIp != null) 'ip',
-          if (privateCountry != null) 'country',
-          if (privateAvatar != null) 'avatar',
-          if (privateEmail != null) 'email',
-          if (privateName != null) 'name',
-          if (privateFirstName != null) 'firstName',
-          if (privateLastName != null) 'lastName',
-        ];
-
-  Map<String, dynamic> toMap() => {
-        'secondary': secondaryKey,
-        'ip': ip,
-        'country': country,
-        'avatar': avatar,
-        'email': email,
-        'name': name,
-        'firstName': firstName,
-        'lastName': lastName,
-      };
-}
+part 'launch_darkly_extensions.dart';
 
 /// Client for accessing LaunchDarkly's Feature Flag system.
 class LaunchdarklyFlutter {
@@ -188,6 +96,7 @@ class LaunchdarklyFlutter {
       return await _channel.invokeMethod('init', <String, dynamic>{
         'mobileKey': mobileKey,
         'config': config?.toMap(),
+        'user': user?.toMap(),
         'custom': {
           if (custom != null) ...custom,
           if (privateCustom != null) ...privateCustom,

--- a/lib/launchdarkly_user.dart
+++ b/lib/launchdarkly_user.dart
@@ -1,0 +1,74 @@
+/// A collection of attributes that can affect flag evaluation, usually corresponding to a user of your application.
+///
+/// If you want to avoid sending personal information back to LaunchDarkly but keep the ability to target user segments, you can configure those attributes as private.
+/// Use `private`-prefixed counterparts for this purpose.
+class LaunchDarklyUser {
+  /// Sets the secondary key for a user. This affects feature flag targeting as follows:
+  /// if you have chosen to bucket users by a specific attribute,
+  /// he secondary key (if set) is used to further distinguish between users who are otherwise identical according to that attribute.
+  final String? secondaryKey;
+
+  /// Sets the IP for a user.
+  final String? ip;
+
+  /// Set the country for a user.
+  final String? country;
+
+  /// Sets the user's avatar.
+  final String? avatar;
+
+  /// Sets the user's e-mail address.
+  final String? email;
+
+  /// Sets the user's full name.
+  final String? name;
+
+  /// Sets the user's first name.
+  final String? firstName;
+
+  /// Sets the user's last name.
+  final String? lastName;
+
+  final List<String> privateAttributes;
+
+  /// Constructor for creating a LaunchDarkly user.
+  /// All parameters are optional.
+  /// Use `private`-prefixed parameters if you want to avoid sending this paramater back to LaunchDarkly.
+  /// Private parameters take precedence over public parameters.
+  /// If both specified, public ones will be ignored.
+  LaunchDarklyUser({
+    String? secondaryKey,
+    String? privateSecondaryKey,
+    String? ip,
+    String? privateIp,
+    String? country,
+    String? privateCountry,
+    String? avatar,
+    String? privateAvatar,
+    String? email,
+    String? privateEmail,
+    String? name,
+    String? privateName,
+    String? firstName,
+    String? privateFirstName,
+    String? lastName,
+    String? privateLastName,
+  })  : this.secondaryKey = privateSecondaryKey ?? secondaryKey,
+        this.ip = privateIp ?? ip,
+        this.country = privateCountry ?? country,
+        this.avatar = privateAvatar ?? avatar,
+        this.email = privateEmail ?? email,
+        this.name = privateName ?? name,
+        this.firstName = privateFirstName ?? firstName,
+        this.lastName = privateLastName ?? lastName,
+        this.privateAttributes = [
+          if (privateSecondaryKey != null) 'secondary',
+          if (privateIp != null) 'ip',
+          if (privateCountry != null) 'country',
+          if (privateAvatar != null) 'avatar',
+          if (privateEmail != null) 'email',
+          if (privateName != null) 'name',
+          if (privateFirstName != null) 'firstName',
+          if (privateLastName != null) 'lastName',
+        ];
+}

--- a/test/launchdarkly_flutter_test.dart
+++ b/test/launchdarkly_flutter_test.dart
@@ -3,7 +3,9 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:launchdarkly_flutter/launchdarkly_config.dart';
 import 'package:launchdarkly_flutter/launchdarkly_flutter.dart';
+import 'package:launchdarkly_flutter/launchdarkly_user.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/launchdarkly_flutter_test.dart
+++ b/test/launchdarkly_flutter_test.dart
@@ -118,17 +118,17 @@ void main() {
   });
 
   test('init with all arguments', () async {
-    final userExpected = LaunchDarklyUser(
-      secondaryKey: 'testSecondaryKey',
-      ip: 'testIp',
-      country: 'testCountry',
-      avatar: 'testAvatar',
-      email: 'testEmail',
-      name: 'testName',
-      firstName: 'testFirstName',
-      lastName: 'testLastName',
-    );
-    final customExpected = {
+    const userExpected = {
+      "secondary": 'testSecondaryKey',
+      "ip": 'testIp',
+      "country": 'testCountry',
+      "avatar": 'testAvatar',
+      "email": 'testEmail',
+      "name": 'testName',
+      "firstName": 'testFirstName',
+      "lastName": 'testLastName',
+    };
+    const customExpected = {
       'string': 'value',
       'boolean': true,
       'number': 10,
@@ -136,8 +136,8 @@ void main() {
     };
     channel.setMockMethodCallHandler((MethodCall methodCall) async {
       Map<dynamic, dynamic> args = methodCall.arguments;
-      final userActual = args['user'].cast<String, dynamic>();
-      if (!mapEquals(userExpected.toMap(), userActual)) {
+      final userActual = args['user'].cast<String, String>();
+      if (!mapEquals(userExpected, userActual)) {
         return false;
       }
       final customActual = args['custom'].cast<String, dynamic>();
@@ -153,31 +153,40 @@ void main() {
     final result = await launchdarklyFlutter.init(
       'MOBILE_KEY',
       'USER_ID',
-      user: userExpected,
+      user: LaunchDarklyUser(
+        secondaryKey: 'testSecondaryKey',
+        ip: 'testIp',
+        country: 'testCountry',
+        avatar: 'testAvatar',
+        email: 'testEmail',
+        name: 'testName',
+        firstName: 'testFirstName',
+        lastName: 'testLastName',
+      ),
       custom: customExpected,
     );
     expect(result, true);
   });
 
   test('init with all private arguments', () async {
-    final userExpected = LaunchDarklyUser(
-      privateSecondaryKey: 'testSecondaryKey',
-      privateIp: 'testIp',
-      privateCountry: 'testCountry',
-      privateAvatar: 'testAvatar',
-      privateEmail: 'testEmail',
-      privateName: 'testName',
-      privateFirstName: 'testFirstName',
-      privateLastName: 'testLastName',
-    );
-    final customExpected = {
+    final userExpected = {
+      "secondary": 'testSecondaryKey',
+      "ip": 'testIp',
+      "country": 'testCountry',
+      "avatar": 'testAvatar',
+      "email": 'testEmail',
+      "name": 'testName',
+      "firstName": 'testFirstName',
+      "lastName": 'testLastName',
+    };
+    const customExpected = {
       'string': 'value',
       'boolean': true,
       'number': 10,
       'null': null,
     };
-    final expectedPrivateAttrbiutes = [
-      'secondaryKey',
+    final expectedPrivateAttributes = [
+      'secondary',
       'ip',
       'country',
       'avatar',
@@ -192,8 +201,8 @@ void main() {
     ]..sort();
     channel.setMockMethodCallHandler((MethodCall methodCall) async {
       Map<dynamic, dynamic> args = methodCall.arguments;
-      final userActual = args['user'].cast<String, dynamic>();
-      if (!mapEquals(userExpected.toMap(), userActual)) {
+      final userActual = args['user'].cast<String, String>();
+      if (!mapEquals(userExpected, userActual)) {
         return false;
       }
       final customActual = args['custom'].cast<String, dynamic>();
@@ -202,7 +211,7 @@ void main() {
       }
       final privateAttributes = args['privateAttributes']?.cast<String>()
         ..sort();
-      if (!listEquals(expectedPrivateAttrbiutes, privateAttributes)) {
+      if (!listEquals(expectedPrivateAttributes, privateAttributes)) {
         return false;
       }
       return true;
@@ -210,7 +219,16 @@ void main() {
     final result = await launchdarklyFlutter.init(
       'MOBILE_KEY',
       'USER_ID',
-      user: userExpected,
+      user: LaunchDarklyUser(
+        privateSecondaryKey: 'testSecondaryKey',
+        privateIp: 'testIp',
+        privateCountry: 'testCountry',
+        privateAvatar: 'testAvatar',
+        privateEmail: 'testEmail',
+        privateName: 'testName',
+        privateFirstName: 'testFirstName',
+        privateLastName: 'testLastName',
+      ),
       privateCustom: customExpected,
     );
     expect(result, true);
@@ -221,17 +239,17 @@ void main() {
   });
 
   test('identify with all arguments', () async {
-    final userExpected = LaunchDarklyUser(
-      secondaryKey: 'testSecondaryKey',
-      ip: 'testIp',
-      country: 'testCountry',
-      avatar: 'testAvatar',
-      email: 'testEmail',
-      name: 'testName',
-      firstName: 'testFirstName',
-      lastName: 'testLastName',
-    );
-    final customExpected = {
+    const userExpected = {
+      "secondary": 'testSecondaryKey',
+      "ip": 'testIp',
+      "country": 'testCountry',
+      "avatar": 'testAvatar',
+      "email": 'testEmail',
+      "name": 'testName',
+      "firstName": 'testFirstName',
+      "lastName": 'testLastName',
+    };
+    const customExpected = {
       'string': 'value',
       'boolean': true,
       'number': 10,
@@ -239,8 +257,8 @@ void main() {
     };
     channel.setMockMethodCallHandler((MethodCall methodCall) async {
       Map<dynamic, dynamic> args = methodCall.arguments;
-      final userActual = args['user'].cast<String, dynamic>();
-      if (!mapEquals(userExpected.toMap(), userActual)) {
+      final userActual = args['user'].cast<String, String>();
+      if (!mapEquals(userExpected, userActual)) {
         return false;
       }
       final customActual = args['custom'].cast<String, dynamic>();
@@ -255,23 +273,32 @@ void main() {
     });
     final result = await launchdarklyFlutter.identify(
       'USER_ID',
-      user: userExpected,
+      user: LaunchDarklyUser(
+        secondaryKey: 'testSecondaryKey',
+        ip: 'testIp',
+        country: 'testCountry',
+        avatar: 'testAvatar',
+        email: 'testEmail',
+        name: 'testName',
+        firstName: 'testFirstName',
+        lastName: 'testLastName',
+      ),
       custom: customExpected,
     );
     expect(result, true);
   });
 
   test('identify with all private arguments', () async {
-    final userExpected = LaunchDarklyUser(
-      privateSecondaryKey: 'testSecondaryKey',
-      privateIp: 'testIp',
-      privateCountry: 'testCountry',
-      privateAvatar: 'testAvatar',
-      privateEmail: 'testEmail',
-      privateName: 'testName',
-      privateFirstName: 'testFirstName',
-      privateLastName: 'testLastName',
-    );
+    const userExpected = {
+      "secondary": 'testSecondaryKey',
+      "ip": 'testIp',
+      "country": 'testCountry',
+      "avatar": 'testAvatar',
+      "email": 'testEmail',
+      "name": 'testName',
+      "firstName": 'testFirstName',
+      "lastName": 'testLastName',
+    };
     final customExpected = {
       'string': 'value',
       'boolean': true,
@@ -279,7 +306,7 @@ void main() {
       'null': null,
     };
     final expectedPrivateAttrbiutes = [
-      'secondaryKey',
+      'secondary',
       'ip',
       'country',
       'avatar',
@@ -294,8 +321,8 @@ void main() {
     ]..sort();
     channel.setMockMethodCallHandler((MethodCall methodCall) async {
       Map<dynamic, dynamic> args = methodCall.arguments;
-      final userActual = args['user'].cast<String, dynamic>();
-      if (!mapEquals(userExpected.toMap(), userActual)) {
+      final userActual = args['user'].cast<String, String>();
+      if (!mapEquals(userExpected, userActual)) {
         return false;
       }
       final customActual = args['custom'].cast<String, dynamic>();
@@ -311,7 +338,16 @@ void main() {
     });
     final result = await launchdarklyFlutter.identify(
       'USER_ID',
-      user: userExpected,
+      user: LaunchDarklyUser(
+        privateSecondaryKey: 'testSecondaryKey',
+        privateIp: 'testIp',
+        privateCountry: 'testCountry',
+        privateAvatar: 'testAvatar',
+        privateEmail: 'testEmail',
+        privateName: 'testName',
+        privateFirstName: 'testFirstName',
+        privateLastName: 'testLastName',
+      ),
       privateCustom: customExpected,
     );
     expect(result, true);


### PR DESCRIPTION
### Requirements

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

### Related issues

#33 Private User Attributes

### Describe the solution you've provided

This PR adds support for built-in user attributes and also an ability to configure both the built-in user attributes and custom attributes as private.

**Built-in attributes**

LaunchDarkly provides set of built-in user attributes like `firstName`, `lastName`, `email`, etc. 

The API was extended to accept a parameter of `LaunchDarklyUser` type in order to those attributes can be passed to LaunchDarkly SDK. 

**Private attributes**

There're three options to configure an attribute as private:
 1. Mark all attributes private globally in the LDClient configuration object.
2. Mark specific attributes private by name globally in the LDClient configuration object.
3. Mark specific attributes private by name for individual users when you construct LDUser objects.

This PR adds support for all three.

In order to configure private attributes globally, pass an optional parameter of  `LaunchDarklyConfig` type to `init` call. `LaunchDarklyConfig` could be extended later for other client configuration options if required.

In order to configure specific attributes as private for individual users, use `private`-prefixed arguments of `LaunchDarklyUser` or the `privateCustom` parameter of `init` / `identify` methods for custom attributes.

### Describe alternatives you've considered

Another solution could be to combine both built-in user attributes and custom attributes in a single free-from map.

I'm not sure the end users of the package will benefit a lot from the ability to distinguish between custom attributes and built-in attributes. So, potentially both custom and built-in user attributes could be simply passed as a free-form map:

```
await launchDarkly.identify(
	"userId", 
	"attributes": {
		"email": "example@example.com",
		"customAttr": "customValue",
	}
}
```

Then, during parsing on the platform side, built-in attributes would be recognized among others and passed to LaunchDarkly SDK using an appropriate method. 
This could also prevent against unintentional usage of built-in user attribute keys as custom keys leading to data loss. From LaunchDarkly Android SDK docs: 
> When set to one of the built-in user attribute keys, this custom attribute will be ignored.

The drawbacks of this approach vs the implemented approach: 
1. No compile-time type safety for the built-in user attributes.
2. The implemented approach follows to the original LaunchDarkly documentation more precisely. So, it might be easier to adopt. 
3. Since the map will accept both custom and built-in attributes, it can't be named `custom` anymore. This introduces **a backward incompatible change**.

### Additional context

[Settings user attributes](https://docs.launchdarkly.com/home/users/attributes)

I would love to hear your feedback! 